### PR TITLE
pcl no longer outputs warnings like: Failed to find match for field 'rgb'

### DIFF
--- a/elevation_mapping/src/ElevationMap.cpp
+++ b/elevation_mapping/src/ElevationMap.cpp
@@ -157,7 +157,7 @@ bool ElevationMap::fuseAll(const bool computeSurfaceNormals)
 
 bool ElevationMap::fuseArea(const Eigen::Vector2d& position, const Eigen::Array2d& length, const bool computeSurfaceNormals)
 {
-  ROS_DEBUG("Requested to fuse an area of the elevation map with center at (%f, %f) and side lenghts (%f, %f)",
+  ROS_DEBUG("Requested to fuse an area of the elevation map with center at (%f, %f) and side lengths (%f, %f)",
             position[0], position[1], length[0], length[1]);
 
   Index topLeftIndex;

--- a/elevation_mapping/src/sensor_processors/SensorProcessorBase.cpp
+++ b/elevation_mapping/src/sensor_processors/SensorProcessorBase.cpp
@@ -31,6 +31,7 @@ SensorProcessorBase::SensorProcessorBase(ros::NodeHandle& nodeHandle, tf::Transf
       mapFrameId_(""),
       robotBaseFrameId_("")
 {
+  pcl::console::setVerbosityLevel(pcl::console::L_ERROR);
 	transformationSensorToMap_.setIdentity();
 	transformListenerTimeout_.fromSec(1.0);
 }


### PR DESCRIPTION
set verbosity level to error